### PR TITLE
Add null check for a successful response whose result is null

### DIFF
--- a/__tests__/rpc-websocket-client.spec.ts
+++ b/__tests__/rpc-websocket-client.spec.ts
@@ -17,7 +17,7 @@ describe('WebSocket', () => {
 
         app = mod.createNestApplication();
         app.useWebSocketAdapter(new WsAdapter());
-        await app.listen(testConfig.port);
+        await app.init();
     });
 
     it(`RpcWebSocketClient`, async () => {

--- a/src/rpc-websocket-client.ts
+++ b/src/rpc-websocket-client.ts
@@ -421,6 +421,9 @@ export class RpcWebSocketClient {
     }
 
     private isRpcError(data: any): data is IRpcError {
+        if (data === null) {
+            return false;
+        }
         return typeof data.code !== 'undefined';
     }
 }


### PR DESCRIPTION
#5 

Because the type guard does not work in runtime, any data including `null` can be passed to `isRpcError()` method.  So null check is required here.